### PR TITLE
ci: use `affected:build` script for pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: 'PR: Build application if affected by changes in feature branch'
         if: env.is-pull-request == 'true'
-        run: yarn build
+        run: yarn affected:build
       - name: 'Merge: Build application'
         if: env.is-merge == 'true'
         run: yarn build


### PR DESCRIPTION
# CI
- Correct the `build` job to use the `affected:build` script for pull requests