### PR TITLE
ci: simplify CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,6 @@ env:
   is-merge: ${{ github.event_name == 'push' }}
   is-pull-request: ${{ github.event_name == 'pull_request' }}
 
-  # Check out
-  checkout-fetch-depth: ${{ github.event_name == 'push' && 1 || 0 }}
-  checkout-ref:
-    ${{ github.event_name == 'pull_request' && github.head_ref || '' }}
-
   # Node.js
   NODE_OPTIONS: --max-old-space-size=6144
 
@@ -29,6 +24,11 @@ concurrency:
   # Run merge runs in sequence. Cancel in progress pull request runs.
   cancel-in-progress: ${{ github.event_name != 'push' }}
 
+permissions:
+  # Required by nrwl/nx-set-shas
+  actions: read
+  contents: read
+
 jobs:
   build:
     name: Build
@@ -38,12 +38,10 @@ jobs:
       - name: Check out source code
         uses: actions/checkout@v3
         with:
-          fetch-depth: ${{ env.checkout-fetch-depth }}
-          ref: ${{ env.checkout-ref }}
+          # Required by nrwl/nx-set-shas
+          fetch-depth: 0
       - name:
-          'PR: Derive appropriate SHAs for base and head for `nx affected`
-          commands'
-        if: github.event_name == 'pull_request'
+          'Derive appropriate SHAs for base and head for `nx affected` commands'
         uses: nrwl/nx-set-shas@v2
       - name: Set up dependencies
         uses: ./.github/actions/setup-dependencies
@@ -63,12 +61,10 @@ jobs:
       - name: Check out source code
         uses: actions/checkout@v3
         with:
-          fetch-depth: ${{ env.checkout-fetch-depth }}
-          ref: ${{ env.checkout-ref }}
+          # Required by nrwl/nx-set-shas
+          fetch-depth: 0
       - name:
-          'PR: Derive appropriate SHAs for base and head for `nx affected`
-          commands'
-        if: github.event_name == 'pull_request'
+          'Derive appropriate SHAs for base and head for `nx affected` commands'
         uses: nrwl/nx-set-shas@v2
       - name: Set up dependencies
         uses: ./.github/actions/setup-dependencies
@@ -88,12 +84,10 @@ jobs:
       - name: Check out source code
         uses: actions/checkout@v3
         with:
-          fetch-depth: ${{ env.checkout-fetch-depth }}
-          ref: ${{ env.checkout-ref }}
+          # Required by nrwl/nx-set-shas
+          fetch-depth: 0
       - name:
-          'PR: Derive appropriate SHAs for base and head for `nx affected`
-          commands'
-        if: github.event_name == 'pull_request'
+          'Derive appropriate SHAs for base and head for `nx affected` commands'
         uses: nrwl/nx-set-shas@v2
       - name: Set up dependencies
         uses: ./.github/actions/setup-dependencies
@@ -113,12 +107,10 @@ jobs:
       - name: Check out source code
         uses: actions/checkout@v3
         with:
-          fetch-depth: ${{ env.checkout-fetch-depth }}
-          ref: ${{ env.checkout-ref }}
+          # Required by nrwl/nx-set-shas
+          fetch-depth: 0
       - name:
-          'PR: Derive appropriate SHAs for base and head for `nx affected`
-          commands'
-        if: github.event_name == 'pull_request'
+          'Derive appropriate SHAs for base and head for `nx affected` commands'
         uses: nrwl/nx-set-shas@v2
       - name: Set up dependencies
         uses: ./.github/actions/setup-dependencies


### PR DESCRIPTION
# CI
- Use the `nrwl/nx-set-shas` action for both PR and merge runs to simplify the workflow
- Always fetch all branches and commits to simplify the workflow

# Security
- Configure strict workflow permissions